### PR TITLE
support user-less URI

### DIFF
--- a/lib/uri/ssh_git.rb
+++ b/lib/uri/ssh_git.rb
@@ -29,7 +29,9 @@ module URI
     # @return [Generic] parsed object
     def self.parse(uri_string)
       host_part, path_part = uri_string.split(':', 2)
-      userinfo, host = host_part.split('@', 2)
+      # There may be no user, so reverse the split to make sure host always
+      # is !nil if host_part was !nil.
+      host, userinfo = host_part.split('@', 2).reverse
       path_part = '/' + path_part unless path_part.start_with?('/')
       Generic.build(userinfo: userinfo, host: host, path: path_part)
     end

--- a/test/test_git.rb
+++ b/test/test_git.rb
@@ -14,6 +14,16 @@ module URI
               )
           end
         end
+        test 'no user' do
+          assert do
+            ::URI::SshGit.parse('example.com:/packsaddle/ruby-uri-ssh_git.git') \
+              == Generic.build(
+                userinfo: '',
+                host: 'example.com',
+                path: '/packsaddle/ruby-uri-ssh_git.git'
+              )
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
git-clone samples the scp-like URI syntax as:

> [user@]host.xz:path/to/repo.git/
> where [] denotes an optional element. Due to the way the parse method
> employed string splits this actually was not supported as optional though.

Reverse the split order on the host_part, so that iff there is no @ in the
host_part the host variable gets assigned the not split host_part and the
userinfo becomes nil (instead of having it the other way around).

Also added a test for this.
