### PR TITLE
Fix Generic.to_s

### DIFF
--- a/lib/uri/ssh_git/generic.rb
+++ b/lib/uri/ssh_git/generic.rb
@@ -12,7 +12,9 @@ module URI
       #
       # @return [String] git repository url via ssh protocol
       def to_s
-        "#{user}@#{host}:#{path}"
+        str = ''
+        str << "#{user}@" if user && !user.empty?
+        str << "#{host}:#{path}"
       end
     end
   end

--- a/lib/uri/ssh_git/generic.rb
+++ b/lib/uri/ssh_git/generic.rb
@@ -6,14 +6,13 @@ module URI
       #   Generic.build(
       #     userinfo: 'git',
       #     host: 'github.com',
-      #     path: '/packsaddle/ruby-uri-ssh_git.git'
+      #     path: 'packsaddle/ruby-uri-ssh_git.git'
       #   ).to_s
       #   #=> 'git@github.com:packsaddle/ruby-uri-ssh_git.git'
       #
       # @return [String] git repository url via ssh protocol
       def to_s
-        show_path = path.slice(1..-1) if path.start_with?('/')
-        "#{user}@#{host}:#{show_path}"
+        "#{user}@#{host}:#{path}"
       end
     end
   end

--- a/test/test_generic.rb
+++ b/test/test_generic.rb
@@ -32,6 +32,20 @@ module URI
           end
         end
       end
+
+      sub_test_case 'no user' do
+        test '#to_s' do
+          params = {
+            userinfo: '',
+            host: 'github.com',
+            path: '/packsaddle/ruby-uri-ssh_git.git'
+          }
+          uri = 'github.com:/packsaddle/ruby-uri-ssh_git.git'
+          assert do
+            Generic.build(params).to_s == uri
+          end
+        end
+      end
     end
   end
 end

--- a/test/test_generic.rb
+++ b/test/test_generic.rb
@@ -8,9 +8,25 @@ module URI
           params = {
             userinfo: 'git',
             host: 'github.com',
-            path: '/packsaddle/ruby-uri-ssh_git.git'
+            path: 'packsaddle/ruby-uri-ssh_git.git'
           }
           uri = 'git@github.com:packsaddle/ruby-uri-ssh_git.git'
+          assert do
+            Generic.build(params).to_s == uri
+          end
+        end
+      end
+
+      sub_test_case 'leading slash' do
+        # Leading slashes must be preserved as they denote aboslute paths
+        # while an absence denotes relative paths.
+        test '#to_s' do
+          params = {
+            userinfo: 'git',
+            host: 'github.com',
+            path: '/packsaddle/ruby-uri-ssh_git.git'
+          }
+          uri = 'git@github.com:/packsaddle/ruby-uri-ssh_git.git'
           assert do
             Generic.build(params).to_s == uri
           end


### PR DESCRIPTION
- to_s must not strip leading slashes as leading slashes denote an absolute path, whereas their absence denotes a relative path
- to_s must not prefix user@ if user is nil or empty as @host:path is not a valid URI
