### PR TITLE
adjust test_git to expect correct results and remove path workaround

### DIFF
--- a/lib/uri/ssh_git.rb
+++ b/lib/uri/ssh_git.rb
@@ -32,7 +32,6 @@ module URI
       # There may be no user, so reverse the split to make sure host always
       # is !nil if host_part was !nil.
       host, userinfo = host_part.split('@', 2).reverse
-      path_part = '/' + path_part unless path_part.start_with?('/')
       Generic.build(userinfo: userinfo, host: host, path: path_part)
     end
   end

--- a/test/test_git.rb
+++ b/test/test_git.rb
@@ -8,7 +8,7 @@ module URI
           params = {
             userinfo: 'git',
             host: 'github.com',
-            path: '/packsaddle/ruby-uri-ssh_git.git'
+            path: 'packsaddle/ruby-uri-ssh_git.git'
           }
           uri = 'git@github.com:packsaddle/ruby-uri-ssh_git.git'
           assert do


### PR DESCRIPTION
It is not quite clear why the workaround was introduced to begin with, but
removing it does not seem to have negative impacts.
